### PR TITLE
fixed registration with email confirmation by user

### DIFF
--- a/classes/UserManager.php
+++ b/classes/UserManager.php
@@ -275,7 +275,17 @@ class UserManager extends StaticFactory
              */
             $user = self::register($data, $automaticActivation);
 
+            if (!$automaticActivation)
+	    {
+                $user->is_activated = true;
+            }
+
             Auth::login($user);
+
+            if (!$automaticActivation)
+	    {
+                $user->is_activated = false;
+            }
 
             /*
              * Preform phase 2 User registration


### PR DESCRIPTION
If I set standart activation of user (with confirmation email), I cant register normally, because inside of registerUser() method has trytement to login user. And as he is not activated yet, it cause exception. This fix will fix this.